### PR TITLE
fixed: CSSHelperWebkit not working for Chrome 40+

### DIFF
--- a/src/main/java/org/vectomatic/dom/svg/impl/CSSHelperWebkit.java
+++ b/src/main/java/org/vectomatic/dom/svg/impl/CSSHelperWebkit.java
@@ -25,13 +25,7 @@ import org.vectomatic.dom.svg.OMSVGStyle;
  */
 public class CSSHelperWebkit extends CSSHelper {
 	public native String getProperty(OMSVGStyle style, String name) /*-{
-		// Webkit returns uri paint values in the form '#uri', instead of 'url(#url)'
-		// which makes it hard to parse these values (because they cannot be
-		// distinguished from '#aabbcc' rgb paint values)
-		var value = style.getPropertyCSSValue(name);
-		if (value != null && typeof value.paintType != "undefined" && value.uri != null && value.uri.length > 0) {
-			return "url(" + value.uri + ")";
-		}
+		// removed: not working call: getPropertyCSSValue
 		return style.getPropertyValue(name);
 	}-*/;
 }


### PR DESCRIPTION
"style.getPropertyCSSValue" is undefined for the current version of Chrome. It seems support for that call was removed:
https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/3VmxWFzcyJc/GFOnJxnWBN0J

My attempt to fix this broken behaviour was to simply call:

return style.getPropertyValue(name);

This seems to fix the problems we currently have in our application. I cannot accurately assess whether the problem is correctly and completely solved with this fix. According to the former written comment, there might be a problem with "named colors", but I do not know how to prove that!