### PR TITLE
Add handling of GWT scheduled commands

### DIFF
--- a/src/main/java/org/vectomatic/dom/svg/impl/DOMHelperImpl.java
+++ b/src/main/java/org/vectomatic/dom/svg/impl/DOMHelperImpl.java
@@ -23,6 +23,7 @@ import org.vectomatic.dom.svg.utils.XPathPrefixResolver;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.impl.SchedulerImpl;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
@@ -182,6 +183,7 @@ public class DOMHelperImpl {
 	 */
 	public void dispatch(NativeEvent event, OMNode node, Element elem) {
 		//Window.alert("type=" + event.getType());
+		SchedulerImpl.INSTANCE.flushEntryCommands();
 		String eventName = event.getType();
 		if ("mouseover".equals(eventName) || "mouseout".equals(eventName)) {
 			// Mouseover and mouseout deserve special treatment
@@ -194,6 +196,7 @@ public class DOMHelperImpl {
 			}
 		}
 		node.dispatch(event);
+		SchedulerImpl.INSTANCE.flushFinallyCommands();
 	}
 
 	/**


### PR DESCRIPTION
In GWT the lifecycle of a DOM Event works as follows:

If a DOM handler of a GWT widget is called, GWT flushes the entry commands of the Scheduler before executing the event handler and flushes finally commands after executing the event handler.

If you call `Scheduler.get().scheduleFinally(..)` in an event handler of a GWT widget , it will be executed at the end of the same javascript event loop execution. In the current version of lib-gwt-svg the scheduler isn't called at all. Therefore the scheduled commands won't be executed until the next GWT DOM handler is called.

This changes in the pull request flush the schedule commands in the same way GWT does.

- before dispatching browser events flush entry commands
- after dispatching browser events flash finally commands