### PR TITLE
Listen to MouseWheelEvent in Firefox

### DIFF
--- a/src/main/java/org/vectomatic/dom/svg/impl/DOMHelperImpl.java
+++ b/src/main/java/org/vectomatic/dom/svg/impl/DOMHelperImpl.java
@@ -104,6 +104,9 @@ public class DOMHelperImpl {
 	public void bindEventListener(Element elem, String eventName) {
 		init();
 		sinkEvents(elem, eventName);
+		if ("mousewheel".equals(eventName)) {
+			sinkEvents(elem, "DOMMouseScroll");
+		}
 	}
 
 	/**
@@ -114,6 +117,9 @@ public class DOMHelperImpl {
 	public void unbindEventListener(Element elem, String eventName) {
 		init();
 		unsinkEvents(elem, eventName);
+		if ("mousewheel".equals(eventName)) {
+			unsinkEvents(elem, "DOMMouseScroll");
+		}
 	}
 
 	/**


### PR DESCRIPTION
I've tried to register a MouseWheelEvent and noticed that on FireFox the event listener is never triggered.
Then i saw that u'r binding events to type's name: 

`DOMHelper.bindEventListener((Element)ot.cast(), type.getName());`  _(OMNode.class line 155)_

I guess that this is a problem since type's returned event name always is "mousewheel" while FireFox listens to "DOMMouseScroll". You will need a special handling here.

(I've made a suggestion based on GWT's Mozilla implementation in com.google.gwt.user.client.impl.DOMImplMozilla)